### PR TITLE
Import KeysView, ValuesView from collections.abc to unblock Python upgrade

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+v0.6.0, 2022-11-16
+    8b992cf Update imports so this library is compatible with Python 3.6+
 v0.5.0, 2020-01-07
     a23febe expose upgraded backref collection class
     95192d5 warning, BREAKING CHANGE: remove support for varargs get query, since it had the possibility of handling ambiguity incorrectly.  remove check for multiget that ensured all values were returned, thus allowing multiget to return fewer values than ids were passed in.  update tests and docs accordingly

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@
 """
 
 __author__ = 'dpepper'
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 
 import setuptools
 

--- a/sqlalchemy_lightening/__init__.py
+++ b/sqlalchemy_lightening/__init__.py
@@ -10,7 +10,7 @@ __all__ = [
 
 
 from classproperties import classproperty
-from collections import KeysView, ValuesView
+from collections.abc import KeysView, ValuesView
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm.exc import NoResultFound
 from stringcase import snakecase


### PR DESCRIPTION
When depending on this library, it's currently not possible to upgrade past Python 3.6 as KeysView, ValuesView and many other things are no longer exposed via `collections` but via `collections.abc` (see: https://github.com/python/cpython/issues/70176). This change is backwards compatible and is tested to work from Python 3.6.* to Python 3.10.* at least.